### PR TITLE
Make page IDs optional

### DIFF
--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -21,9 +21,19 @@ describe('markedPages', () => {
     expect(markedPages().options()).toHaveProperty('regex', /\\page/gm);
   });
 
+  test('options check - disable page IDs', () => {
+    marked.use(markedPages({ pageIds: false }));
+    expect(markedPages().options()).toHaveProperty('pageIds', false);
+  });
+
   test('lexer output', () => {
     marked.use(markedPages());
     expect(marked.lexer(' ')[0]).toHaveProperty('type', 'pageBlock');
+  });
+
+  test('parser output', () => {
+    marked.use(markedPages());
+    expect(marked.parse(' ')).toBe('<div class=\'page\' id=\'p1\'>\n</div>');
   });
 
   test('markdown including \\page', () => {

--- a/spec/index.test.js
+++ b/spec/index.test.js
@@ -1,29 +1,44 @@
 import { marked } from 'marked';
 import markedPages from '../src/index.js';
 
-describe('markedPages', () => {
+describe('1. Extension disabled', () => {
   beforeEach(() => {
     marked.setOptions(marked.getDefaults());
-  });
-
-  test('no options', () => {
-    marked.use(markedPages());
-    expect(marked('example')).toBe('<div class=\'page\' id=\'p1\'>\n<p>example</p>\n</div>');
   });
 
   test('markdown not using this extension', () => {
     marked.use(markedPages({ enable: false }));
     expect(marked('**standard markdown**')).toBe('<p><strong>standard markdown</strong></p>\n');
   });
+});
 
-  test('options check', () => {
-    marked.use(markedPages());
-    expect(markedPages().options()).toHaveProperty('regex', /\\page/gm);
+describe('2. Options Reporting', () => {
+  beforeEach(() => {
+    marked.setOptions(marked.getDefaults());
+  });
+
+  test('options check - defaults', () => {
+    const defaultOptions = {
+      enable: true,
+      pageIds: true,
+      term: '\\\\page',
+      regex: /\\page/gm
+    };
+    expect(markedPages().options()).toEqual(defaultOptions);
+  });
+
+  test('options check - regex generated from term', () => {
+    expect(markedPages({ term: 'a' }).options()).toHaveProperty('regex', /a/gm);
   });
 
   test('options check - disable page IDs', () => {
-    marked.use(markedPages({ pageIds: false }));
-    expect(markedPages().options()).toHaveProperty('pageIds', false);
+    expect(markedPages({ pageIds: false }).options()).toHaveProperty('pageIds', false);
+  });
+});
+
+describe('3. Testing with default options', () => {
+  beforeEach(() => {
+    marked.setOptions(marked.getDefaults());
   });
 
   test('lexer output', () => {
@@ -49,5 +64,37 @@ describe('markedPages', () => {
   test('multiple pages - parser', () => {
     marked.use(markedPages());
     expect(marked.parse('this is page 1\n\\page\nthis is page 2\n\\page\nthis is page 3')).toBe('<div class=\'page\' id=\'p1\'>\n<p>this is page 1</p>\n</div><div class=\'page\' id=\'p2\'>\n<p>this is page 2</p>\n</div><div class=\'page\' id=\'p3\'>\n<p>this is page 3</p>\n</div>');
+  });
+});
+
+describe('4. Option: "pageIds: false"', () => {
+  beforeEach(() => {
+    marked.setOptions(marked.getDefaults());
+  });
+
+  test('single page', () => {
+    marked.use(markedPages({ pageIds: false }));
+    expect(marked.parse(' ')).toBe('<div class=\'page\'>\n</div>');
+  });
+
+  test('multiple pages', () => {
+    marked.use(markedPages({ pageIds: false }));
+    expect(marked.parse('page 1\n\\page\npage 2\n\\page\npage 3')).toBe('<div class=\'page\'>\n<p>page 1</p>\n</div><div class=\'page\'>\n<p>page 2</p>\n</div><div class=\'page\'>\n<p>page 3</p>\n</div>');
+  });
+});
+
+describe('5. Option: "term: XYZZY"', () => {
+  beforeEach(() => {
+    marked.setOptions(marked.getDefaults());
+  });
+
+  test('single page', () => {
+    marked.use(markedPages({ term: 'XYZZY' }));
+    expect(marked.parse(' ')).toBe('<div class=\'page\' id=\'p1\'>\n</div>');
+  });
+
+  test('multiple pages', () => {
+    marked.use(markedPages({ term: 'XYZZY' }));
+    expect(marked.parse('page 1\nXYZZY\npage 2\nXYZZY\npage 3')).toBe('<div class=\'page\' id=\'p1\'>\n<p>page 1</p>\n</div><div class=\'page\' id=\'p2\'>\n<p>page 2</p>\n</div><div class=\'page\' id=\'p3\'>\n<p>page 3</p>\n</div>');
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-export default function(options = { enable: true, term: '\\\\page' }) {
+export default function(options = { enable: true, term: '\\\\page', pageIds: true }) {
   // extension code here
   if (!options.enable) return false;
 
@@ -32,7 +32,7 @@ export default function(options = { enable: true, term: '\\\\page' }) {
           return token;
         },
         renderer(token) {
-          return `<div class='page' id='p${token.pageNumber}'>\n${this.parser.parse(token.tokens)}</div>`;
+          return `<div class='page' ${options.pageIds ? 'id='p${token.pageNumber}' : ''}>\n${this.parser.parse(token.tokens)}</div>`;
         }
       }
     ]

--- a/src/index.js
+++ b/src/index.js
@@ -36,7 +36,7 @@ export default function(options = { enable: true, term: '\\\\page', pageIds: tru
           return token;
         },
         renderer(token) {
-          return `<div class='page' ${options.pageIds ? "id='p${token.pageNumber}'" : ''}>\n${this.parser.parse(token.tokens)}</div>`;
+          return `<div class='page' ${options.pageIds ? `id='p${token.pageNumber}'` : ''}>\n${this.parser.parse(token.tokens)}</div>`;
         }
       }
     ]

--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ export default function(options = { enable: true, term: '\\\\page', pageIds: tru
           return token;
         },
         renderer(token) {
-          return `<div class='page' ${options.pageIds ? 'id='p${token.pageNumber}' : ''}>\n${this.parser.parse(token.tokens)}</div>`;
+          return `<div class='page' ${options.pageIds ? "id='p${token.pageNumber}'" : ''}>\n${this.parser.parse(token.tokens)}</div>`;
         }
       }
     ]

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,12 @@
-export default function(options = { enable: true, term: '\\\\page', pageIds: true }) {
-  // extension code here
+export default function(opts) {
+  const defaultOptions = {
+    enable: true,
+    term: '\\\\page',
+    pageIds: true
+  };
+
+  const options = { ...defaultOptions, ...opts };
+
   if (!options.enable) return false;
 
   /* istanbul ignore else */
@@ -36,7 +43,7 @@ export default function(options = { enable: true, term: '\\\\page', pageIds: tru
           return token;
         },
         renderer(token) {
-          return `<div class='page' ${options.pageIds ? `id='p${token.pageNumber}'` : ''}>\n${this.parser.parse(token.tokens)}</div>`;
+          return `<div class='page'${options.pageIds ? ` id='p${token.pageNumber}'` : ''}>\n${this.parser.parse(token.tokens)}</div>`;
         }
       }
     ]


### PR DESCRIPTION
This change makes page IDs optional, and adds a configuration item to enable or disable that feature.